### PR TITLE
fix format parameter

### DIFF
--- a/R/functions/tar-qc_plink.R
+++ b/R/functions/tar-qc_plink.R
@@ -1013,7 +1013,7 @@ plot_pca_ethnicty <- function(data, pve, loadings) {
       title = "Ethnicity Inference Based On 1,000 Genomes Project Data",
       subtitle = paste0(
         "Principal Component Analysis using ",
-        format(nrow(loadings), big.mark = ",", digits = 0),
+        format(nrow(loadings), big.mark = ",", digits = digits = 1L, nsmall = 0L),
         " SNPs, with <b>A</b>) population level, and <b>B</b>) super population level."
       ),
       tag_levels = "A",


### PR DESCRIPTION
digits = 0 is no longer supported in R version 4.*. Use interger, explicit nsmall. 

bug ever reported in same context https://github.com/umr1283/rain/pull/3/commits